### PR TITLE
fixes ZEN-12760: add new addnote api method that does not force indexing

### DIFF
--- a/python/zenoss/protocols/services/zep.py
+++ b/python/zenoss/protocols/services/zep.py
@@ -86,6 +86,18 @@ class ZepServiceClient(object):
 
         return self.client.post('%s/notes' % uuid, body=note)
 
+    def addNoteBulkAsync(self, uuids, message, userUuid=None, userName=None):
+        """
+        Add a note (what used to be called log) to several event summaries.
+        """
+
+        note = from_dict(EventNote, dict(
+            user_uuid = userUuid,
+            user_name = userName,
+            message = message
+        ))
+
+        return self.client.post('notes_async', body=note, params={'uuid': uuids})
 
     def postNote(self, uuid, note):
         return self.client.post('{0}/notes'.format(uuid), body=note)


### PR DESCRIPTION
DEMO:
  https://jira.zenoss.com/secure/attachment/18466/fix-for-ZEN-12760.png

port of:
  https://jira.zenoss.com/browse/ZEN-12761
  https://github.com/zenoss/pm-resmgr-4.2.4/pull/568

fixes:
  https://github.com/zenoss/zenoss-zep/pull/28
  https://github.com/zenoss/zenoss-protocols/pull/9
  https://github.com/zenoss/zenoss-prodbin/pull/249
