### PR TITLE
Check if a queue exists before trying to create it

### DIFF
--- a/python/zenoss/protocols/adapters.py
+++ b/python/zenoss/protocols/adapters.py
@@ -32,15 +32,19 @@ class AMQPLibChannelAdapter(object):
     def __init__(self, channel):
         self.channel = channel
 
-    def declareQueue(self, queue):
-        log.debug("Creating queue: %s", queue.name)
+    def declareQueue(self, queue, passive):
+        if passive:
+            log.debug("Checking queue: %s", queue.name)
+        else:
+            log.debug("Creating queue: %s", queue.name)
         log.debug("Using arguments: %r", queue.arguments)
         try:
             result = self.channel.queue_declare(queue=queue.name,
                                                 durable=queue.durable,
                                                 exclusive=queue.exclusive,
                                                 auto_delete=queue.auto_delete,
-                                                arguments=queue.arguments)
+                                                arguments=queue.arguments,
+                                                passive=passive)
         except AMQPChannelException as e:
             raise ChannelClosedError(e)
 
@@ -86,15 +90,19 @@ class TwistedChannelAdapter(object):
         self.channel = channel
 
     @inlineCallbacks
-    def declareQueue(self, queue):
-        log.debug("Creating queue: %s", queue.name)
+    def declareQueue(self, queue, passive):
+        if passive:
+            log.debug("Checking queue: %s", queue.name)
+        else:
+            log.debug("Creating queue: %s", queue.name)
         log.debug("Using arguments: %r", queue.arguments)
         try:
             result = yield self.channel.queue_declare(queue=queue.name,
                                                       durable=queue.durable,
                                                       exclusive=queue.exclusive,
                                                       auto_delete=queue.auto_delete,
-                                                      arguments=queue.arguments)
+                                                      arguments=queue.arguments,
+                                                      passive=passive)
         except Closed as e:
             raise ChannelClosedError(e)
 

--- a/python/zenoss/protocols/interfaces.py
+++ b/python/zenoss/protocols/interfaces.py
@@ -135,7 +135,7 @@ class IAMQPChannelAdapter(Interface):
     exchange using the IQueue or IExchange returned from the queue schema.
     """
 
-    def declareQueue(queue):
+    def declareQueue(queue, passive):
         """
         Creates the queue and binds it to the exchange(s).
 

--- a/python/zenoss/protocols/twisted/amqp.py
+++ b/python/zenoss/protocols/twisted/amqp.py
@@ -156,10 +156,11 @@ class AMQProtocol(AMQClient):
         except ChannelClosedError as e:
             log.debug(("Channel {0} doesn't exist, attempting to create it.").format(queue.name))
             self.chan = yield self.get_channel()
+        finally:
+            self._checking = False
 
         # Declare the queue
         try:
-            self._checking = False
             yield getAdapter(self.chan, IAMQPChannelAdapter).declareQueue(queue, False)
         except ChannelClosedError as e:
             # Here we handle the case where we redeclare a queue 


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28918

If the arguments used to create the queue are different from the arguments zenoss-protocols is trying to create it as, the create will fail and we can't connect to the queue.  If the queue exists, use the queue as-is without trying to create it.
